### PR TITLE
Insert cachebreakers into the filename

### DIFF
--- a/fixture/fixture.html
+++ b/fixture/fixture.html
@@ -2,8 +2,7 @@
   <head>
     <script src="{{cache-break:fixture.js}}"></script>
     <script src="{{cache-break:/fixture.js}}"></script>
-    <script src="{{cache-break:/does-not-exist.js}}"></script>
-    <script src="{{cache-break://external.js}}"></script>
+    <script src="{{cdn-path:/fixture.js}}"></script>
     <script src="/do/not/cache-break.js"></script>
   </head>
   <body></body>

--- a/index.js
+++ b/index.js
@@ -35,9 +35,10 @@ CacheBreaker.prototype.cacheBreakPath = function(base, resource) {
   return path.join(dirname, basename + '.' + cs.substring(0, 10) + extname);
 };
 
-CacheBreaker.prototype.cdnUri = function(base, resource, host) {
+CacheBreaker.prototype.cdnUri = function(base, resource, host, secure) {
   if (host) {
-    return 'https://' + host + this.cacheBreakPath(base, resource);
+    var prefix = (secure === false ? 'http://' : 'https://');
+    return prefix + host + this.cacheBreakPath(base, resource);
   } else {
     return this.cacheBreakPath(base, resource);
   }
@@ -49,9 +50,9 @@ CacheBreaker.prototype.gulpCbPath = function(base) {
   }.bind(this));
 };
 
-CacheBreaker.prototype.gulpCdnUri = function(base, host) {
+CacheBreaker.prototype.gulpCdnUri = function(base, host, secure) {
   return replace(reCdnPath, function(match, resource) {
-    return this.cdnUri(base, resource, host);
+    return this.cdnUri(base, resource, host, secure);
   }.bind(this));
 };
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var cb = require('./');
+var CacheBreaker = require('./');
 var assert = require('assert');
 var gutil = require('gulp-util');
 var format = require('util').format;
@@ -6,35 +6,59 @@ var checksum = require('checksum');
 var fs = require('fs');
 
 it('break the cache as is appropriate', function(done) {
-	var s = cb('fixture/');
+  var cb = new CacheBreaker();
+  var s = cb.gulpCbPath('fixture/');
   var path = __dirname + '/fixture/fixture.html';
   var contents = fs.readFileSync(path);
-  var cs = checksum(fs.readFileSync(__dirname + '/fixture/fixture.js').toString());
+  var cs = checksum(fs.readFileSync(__dirname + '/fixture/fixture.js')).substring(0, 10);
 
-	s.on('data', function(file) {
-		var fc = file.contents.toString();
+  s.on('data', function(file) {
+    var fc = file.contents.toString();
 
-		assert(fc.indexOf(format('<script src="fixture.js?cb=%s"></script>', cs)) !== -1);
+    assert(fc.indexOf(format('<script src="fixture.%s.js"></script>', cs)) !== -1);
 
-    assert(fc.indexOf(format('<script src="fixture.js?cb=%s"></script>', cs)) !== -1);
-
-    assert(fc.match(/does-not-exist\.js\?cb=\d{13}/));
-
-		assert(fc.match(/\/\/external\.js\?cb=\d{13}/));
+    assert(fc.indexOf(format('<script src="/fixture.%s.js"></script>', cs)) !== -1);
 
     assert(fc.indexOf('<script src="/do/not/cache-break.js"></script>') !== -1);
 
-		assert.equal(file.relative, 'fixture.html');
-	});
+    assert.equal(file.relative, 'fixture.html');
+  });
 
-	s.on('end', done);
+  s.on('end', done);
 
-	s.write(new gutil.File({
-		cwd: __dirname,
-		base: __dirname + '/fixture',
-		path: path,
-		contents: fs.readFileSync(path)
-	}));
+  s.write(new gutil.File({
+    cwd: __dirname,
+    base: __dirname + '/fixture',
+    path: path,
+    contents: fs.readFileSync(path)
+  }));
 
-	s.end();
+  s.end();
+});
+
+it('sets the CDN URI', function(done) {
+  var cb = new CacheBreaker();
+  var s = cb.gulpCdnUri('fixture/', 'foo.cloudfront.net');
+  var path = __dirname + '/fixture/fixture.html';
+  var contents = fs.readFileSync(path);
+  var cs = checksum(fs.readFileSync(__dirname + '/fixture/fixture.js')).substring(0, 10);
+
+  s.on('data', function(file) {
+    var fc = file.contents.toString();
+
+    assert(fc.indexOf(format('<script src="https://foo.cloudfront.net/fixture.%s.js"></script>', cs)) !== -1);
+
+    assert.equal(file.relative, 'fixture.html');
+  });
+
+  s.on('end', done);
+
+  s.write(new gutil.File({
+    cwd: __dirname,
+    base: __dirname + '/fixture',
+    path: path,
+    contents: fs.readFileSync(path)
+  }));
+
+  s.end();
 });

--- a/test.js
+++ b/test.js
@@ -62,3 +62,30 @@ it('sets the CDN URI', function(done) {
 
   s.end();
 });
+
+it('sets the insecure CDN URI', function(done) {
+  var cb = new CacheBreaker();
+  var s = cb.gulpCdnUri('fixture/', 'foo.cloudfront.net', false);
+  var path = __dirname + '/fixture/fixture.html';
+  var contents = fs.readFileSync(path);
+  var cs = checksum(fs.readFileSync(__dirname + '/fixture/fixture.js')).substring(0, 10);
+
+  s.on('data', function(file) {
+    var fc = file.contents.toString();
+
+    assert(fc.indexOf(format('<script src="http://foo.cloudfront.net/fixture.%s.js"></script>', cs)) !== -1);
+
+    assert.equal(file.relative, 'fixture.html');
+  });
+
+  s.on('end', done);
+
+  s.write(new gutil.File({
+    cwd: __dirname,
+    base: __dirname + '/fixture',
+    path: path,
+    contents: fs.readFileSync(path)
+  }));
+
+  s.end();
+});


### PR DESCRIPTION
We now insert cachebreakers directly into the filename (and produce symlinks so we can serve them).

This removes the fallback to a time-based cache-breaker. It just blows up if the file doesn't exist locally (which I figure is what we want as it's almost certainly operator error if it doesn't).
